### PR TITLE
fix handling of @param tags

### DIFF
--- a/src/test/java/com/elharo/docfix/DocFixTest.java
+++ b/src/test/java/com/elharo/docfix/DocFixTest.java
@@ -36,17 +36,6 @@ public class DocFixTest {
         }
     }
 
-    /**
-     * Test that ComplexNumber.java contains the string "ChatGPT".
-     * Mostly this just verifies that we can read a test resource as a
-     * prerequisite for tests of the functionality. This is traditionally
-     * a rather tricky thing to make work, and one I almost always have trouble with.
-     * Copilot+ChatGPT did a pretty good job here.
-     */
-    @Test
-    public void testComplexNumberResourceContainsChatGPT() {
-        assertTrue("Resource does not contain 'ChatGPT'", code.contains("ChatGPT"));
-    }
 
     /** 
      * I need to think about the API now. This is where TDD shines.
@@ -216,5 +205,20 @@ public class DocFixTest {
         // Output should show the fix
         assertTrue(output.contains("     * the imaginary part of the complex number."));
         assertTrue(output.contains("     * The imaginary part of the complex number."));
+    }
+
+    // needs to work on params
+        /** 
+     * I need to think about the API now. This is where TDD shines.
+     * Probably all I really want is a method that takes as an argument
+     * a string containing the code and returns a string containing the fixed code.
+     * I can add overloaded variants that take a file, input stream, or reader.
+     * I would have come up with something much more complex if I jumped straight to implementation.
+     */
+    @Test
+    public void testAtParam() {
+        String fixed = DocFix.fix(code);
+        assertFalse(fixed, fixed.contains("     * @param real The real part"));
+        assertTrue(fixed, fixed.contains("     * @param real the real part"));
     }
 }


### PR DESCRIPTION
1. Notice a failure when using the program on a real world file.
2. Write a failing test (manually)
3. Ask CoPIlot in agent mode to make all the test pass again. Prompt:

I've added a failing test testAtParam. Modify DocFix so that this and all other tests still pass. The code should avoid inserting new line breaks. It should only modify line by line. It should recognize the difference bwteen the method comments and Javadoc tags. method comments have initial capital letters. the text of a Javadoc tag does not

I'm noticing one downside of this approach. I'm about to commit this code before fully understanding how it operates. This algorithm isn't super-opaque but if I'd written the code myself, I'd have more confidence that I knew how it operated.

Looking at it, I am concerned that it's very regular expression heavy rather than using more parser logic.
