### PR TITLE
Claude code written method for finding doc comments

### DIFF
--- a/src/main/java/com/elharo/docfix/FileParser.java
+++ b/src/main/java/com/elharo/docfix/FileParser.java
@@ -1,0 +1,66 @@
+package com.elharo.docfix;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for parsing Java files line by line, with special handling
+ * for Javadoc comments.
+ */
+public class FileParser {
+
+    /**
+     * Reads a Java file line by line and returns a list of strings.
+     * If a line starts a Javadoc comment, reads all lines until the end
+     * of the Javadoc comment and stores that as a single string.
+     * Otherwise, stores each individual line as a separate string.
+     *
+     * @param path the path to the Java file to read
+     * @return a list of strings representing the file content
+     * @throws IOException if an I/O error occurs reading the file
+     */
+    public static List<String> parseFile(Path path) throws IOException {
+        List<String> lines = Files.readAllLines(path);
+        List<String> result = new ArrayList<>();
+        
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            String trimmed = line.trim();
+            
+            // Check if this line starts a Javadoc comment
+            if (trimmed.startsWith("/**")) {
+                StringBuilder javadocBuilder = new StringBuilder();
+                javadocBuilder.append(line);
+                
+                // If the comment doesn't end on the same line, continue reading
+                if (!trimmed.endsWith("*/")) {
+                    javadocBuilder.append("\n");
+                    i++; // Move to next line
+                    
+                    // Read until we find the end of the Javadoc comment
+                    while (i < lines.size()) {
+                        String currentLine = lines.get(i);
+                        javadocBuilder.append(currentLine);
+                        
+                        if (currentLine.trim().endsWith("*/")) {
+                            break;
+                        }
+                        
+                        javadocBuilder.append("\n");
+                        i++;
+                    }
+                }
+                
+                result.add(javadocBuilder.toString());
+            } else {
+                // Regular line, add as-is
+                result.add(line);
+            }
+        }
+        
+        return result;
+    }
+}


### PR DESCRIPTION
Taking a different approach to parsing to work on #30 

The idea here is mine but I let Claude write the code. The prompt is 


Write a class named com.elharo.docfix.FileParser with a static method that takes a Path as an argument.
The method reads the .java file indicated by the path line by line and returns a list of strings.
If a line starts a javadoc comment, read all lines until the end of the javadoc comment and store that into a string which is added to the list. Otherwise just store the single line into a string and add it to the list.



This misses a few unlikely edge cases that can be cleaned up later.
