### PR TITLE
support single line comments

### DIFF
--- a/src/main/java/com/elharo/docfix/DocComment.java
+++ b/src/main/java/com/elharo/docfix/DocComment.java
@@ -18,9 +18,9 @@ class DocComment {
   final boolean hasTrailingBlankLine; // Whether there's a blank line after the last block tag
 
   // Indentation to be applied before entire comment
-  private final String indent;
+  protected final String indent;
 
-  private DocComment(Kind kind, String description, List<BlockTag> blockTags, int indent,
+  protected DocComment(Kind kind, String description, List<BlockTag> blockTags, int indent,
       boolean hasTrailingBlankLine) {
     this.kind = kind;
     if (description != null && !description.isEmpty()) {
@@ -40,11 +40,18 @@ class DocComment {
     // Remove leading/trailing comment markers and split into lines
     // TODO could just keep the beginning and end markers
     String body = raw.trim();
+    boolean singleLine = !body.contains("\n");
     if (body.startsWith("/**")) {
       body = body.substring(3);
     }
     if (body.endsWith("*/")) {
       body = body.substring(0, body.length() - 2).trim();
+    }
+    
+    // If it's a single line comment with no block tags, return a SingleLineComment
+    if (singleLine && !body.contains("@")) {
+      String description = body.trim();
+      return new SingleLineComment(kind, description, tagIndent);
     }
     String[] lines = body.split("\r?\n");
     StringBuilder description = new StringBuilder();

--- a/src/main/java/com/elharo/docfix/DocComment.java
+++ b/src/main/java/com/elharo/docfix/DocComment.java
@@ -120,15 +120,15 @@ class DocComment {
     return indent;
   }
 
-  Kind getKind() {
+  final Kind getKind() {
     return kind;
   }
 
-  String getDescription() {
+  final String getDescription() {
     return description;
   }
 
-  List<BlockTag> getBlockTags() {
+  final List<BlockTag> getBlockTags() {
     return blockTags;
   }
 

--- a/src/main/java/com/elharo/docfix/SingleLineComment.java
+++ b/src/main/java/com/elharo/docfix/SingleLineComment.java
@@ -3,34 +3,34 @@ package com.elharo.docfix;
 import java.util.Collections;
 
 /**
- * Represents a single-line Javadoc comment where the description does not
- * contain line breaks and has no block tags. The comment markers appear
+ * Represents a single-line Javadoc comment that has no block tags and
+ * where the description does not contain line breaks. The comment markers appear
  * on the same line as the description.
  */
 class SingleLineComment extends DocComment {
 
-    SingleLineComment(Kind kind, String description, int indent) {
-        super(kind, description, Collections.emptyList(), indent, false);
-    }
+  SingleLineComment(Kind kind, String description, int indent) {
+    super(kind, description, Collections.emptyList(), indent, false);
+  }
 
-    /**
-     * Converts this SingleLineComment to a JavaDoc comment string.
-     *
-     * @return the single-line JavaDoc comment as a string
-     */
-    @Override
-    String toJava() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(indent).append("/** ");
-        if (description != null && !description.isEmpty()) {
-            String desc = description;
-            // Add period if description doesn't end with punctuation
-            if (!desc.endsWith(".") && !desc.endsWith("!") && !desc.endsWith("?")) {
-                desc += ".";
-            }
-            sb.append(desc);
-        }
-        sb.append(" */");
-        return sb.toString();
+  /**
+   * Converts this SingleLineComment to a JavaDoc comment string.
+   *
+   * @return the single-line JavaDoc comment as a string
+   */
+  @Override
+  String toJava() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(indent).append("/** ");
+    if (description != null && !description.isEmpty()) {
+      String desc = description;
+      // Add period if description doesn't end with punctuation
+      if (!desc.endsWith(".") && !desc.endsWith("!") && !desc.endsWith("?")) {
+        desc += ".";
+      }
+      sb.append(desc);
     }
+    sb.append(" */");
+    return sb.toString();
+  }
 }

--- a/src/main/java/com/elharo/docfix/SingleLineComment.java
+++ b/src/main/java/com/elharo/docfix/SingleLineComment.java
@@ -1,0 +1,36 @@
+package com.elharo.docfix;
+
+import java.util.Collections;
+
+/**
+ * Represents a single-line Javadoc comment where the description does not
+ * contain line breaks and has no block tags. The comment markers appear
+ * on the same line as the description.
+ */
+class SingleLineComment extends DocComment {
+
+    SingleLineComment(Kind kind, String description, int indent) {
+        super(kind, description, Collections.emptyList(), indent, false);
+    }
+
+    /**
+     * Converts this SingleLineComment to a JavaDoc comment string.
+     *
+     * @return the single-line JavaDoc comment as a string
+     */
+    @Override
+    String toJava() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(indent).append("/** ");
+        if (description != null && !description.isEmpty()) {
+            String desc = description;
+            // Add period if description doesn't end with punctuation
+            if (!desc.endsWith(".") && !desc.endsWith("!") && !desc.endsWith("?")) {
+                desc += ".";
+            }
+            sb.append(desc);
+        }
+        sb.append(" */");
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/elharo/docfix/DocCommentTest.java
+++ b/src/test/java/com/elharo/docfix/DocCommentTest.java
@@ -89,6 +89,14 @@ public class DocCommentTest {
   }
 
   @Test
+  public void testSingleLine() {
+    DocComment docComment = DocComment.parse(Kind.FIELD,
+        "/** a single line comment */");
+    String java = docComment.toJava();
+    assertEquals(java, "/** A single line comment. */");
+  }
+
+  @Test
   public void testPreserveDoubleSpace() {
     DocComment docComment = DocComment.parse(Kind.CLASS,
         "    /**\n"

--- a/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
+++ b/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
@@ -2,7 +2,9 @@ package com.elharo.docfix;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class SingleLineCommentTest {
 

--- a/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
+++ b/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
@@ -1,79 +1,82 @@
 package com.elharo.docfix;
 
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class SingleLineCommentTest {
 
-    @Test
-    public void testParseSingleLineComment() {
-        String raw = "/** This is a single line comment */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals(DocComment.Kind.METHOD, comment.getKind());
-        assertEquals("This is a single line comment", comment.getDescription());
-        assertTrue(comment.getBlockTags().isEmpty());
-    }
+  @Test
+  public void testParseSingleLineComment() {
+    String raw = "/** This is a single line comment */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
 
-    @Test
-    public void testToJava() {
-        String raw = "/** This is a single line comment */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals("/** This is a single line comment. */", comment.toJava());
-    }
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals(DocComment.Kind.METHOD, comment.getKind());
+    assertEquals("This is a single line comment", comment.getDescription());
+    assertTrue(comment.getBlockTags().isEmpty());
+  }
 
-    @Test
-    public void testWithIndentation() {
-        String raw = "    /** Indented single line comment */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals("    /** Indented single line comment. */", comment.toJava());
-    }
+  @Test
+  public void testToJava() {
+    String raw = "/** This is a single line comment */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
 
-    @Test
-    public void testMultiLineCommentReturnsDocComment() {
-        String raw = "/**\n * This is a multi-line comment\n */";
-        DocComment comment = DocComment.parse(DocComment.Kind.CLASS, raw);
-        
-        assertFalse("Should NOT return a SingleLineComment instance", comment instanceof SingleLineComment);
-    }
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals("/** This is a single line comment. */", comment.toJava());
+  }
 
-    @Test
-    public void testCommentWithBlockTagsReturnsDocComment() {
-        String raw = "/** This has @param tag */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertFalse("Should NOT return a SingleLineComment instance", comment instanceof SingleLineComment);
-    }
+  @Test
+  public void testWithIndentation() {
+    String raw = "    /** Indented single line comment */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
 
-    @Test
-    public void testDoesNotDuplicatePeriod() {
-        String raw = "/** This already has a period. */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals("/** This already has a period. */", comment.toJava());
-    }
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals("    /** Indented single line comment. */", comment.toJava());
+  }
 
-    @Test
-    public void testHandlesExclamationMark() {
-        String raw = "/** This has an exclamation! */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals("/** This has an exclamation! */", comment.toJava());
-    }
+  @Test
+  public void testMultiLineCommentReturnsDocComment() {
+    String raw = "/**\n * This is a multi-line comment\n */";
+    DocComment comment = DocComment.parse(DocComment.Kind.CLASS, raw);
 
-    @Test
-    public void testHandlesQuestionMark() {
-        String raw = "/** Is this a question? */";
-        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
-        
-        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
-        assertEquals("/** Is this a question? */", comment.toJava());
-    }
+    assertFalse("Should NOT return a SingleLineComment instance",
+        comment instanceof SingleLineComment);
+  }
+
+  @Test
+  public void testCommentWithBlockTagsReturnsDocComment() {
+    String raw = "/** This has @param tag */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+
+    assertFalse("Should NOT return a SingleLineComment instance",
+        comment instanceof SingleLineComment);
+  }
+
+  @Test
+  public void testDoesNotDuplicatePeriod() {
+    String raw = "/** This already has a period. */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals("/** This already has a period. */", comment.toJava());
+  }
+
+  @Test
+  public void testHandlesExclamationMark() {
+    String raw = "/** This has an exclamation! */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals("/** This has an exclamation! */", comment.toJava());
+  }
+
+  @Test
+  public void testHandlesQuestionMark() {
+    String raw = "/** Is this a question? */";
+    DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+
+    assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+    assertEquals("/** Is this a question? */", comment.toJava());
+  }
 }

--- a/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
+++ b/src/test/java/com/elharo/docfix/SingleLineCommentTest.java
@@ -1,0 +1,79 @@
+package com.elharo.docfix;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SingleLineCommentTest {
+
+    @Test
+    public void testParseSingleLineComment() {
+        String raw = "/** This is a single line comment */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals(DocComment.Kind.METHOD, comment.getKind());
+        assertEquals("This is a single line comment", comment.getDescription());
+        assertTrue(comment.getBlockTags().isEmpty());
+    }
+
+    @Test
+    public void testToJava() {
+        String raw = "/** This is a single line comment */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals("/** This is a single line comment. */", comment.toJava());
+    }
+
+    @Test
+    public void testWithIndentation() {
+        String raw = "    /** Indented single line comment */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals("    /** Indented single line comment. */", comment.toJava());
+    }
+
+    @Test
+    public void testMultiLineCommentReturnsDocComment() {
+        String raw = "/**\n * This is a multi-line comment\n */";
+        DocComment comment = DocComment.parse(DocComment.Kind.CLASS, raw);
+        
+        assertFalse("Should NOT return a SingleLineComment instance", comment instanceof SingleLineComment);
+    }
+
+    @Test
+    public void testCommentWithBlockTagsReturnsDocComment() {
+        String raw = "/** This has @param tag */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertFalse("Should NOT return a SingleLineComment instance", comment instanceof SingleLineComment);
+    }
+
+    @Test
+    public void testDoesNotDuplicatePeriod() {
+        String raw = "/** This already has a period. */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals("/** This already has a period. */", comment.toJava());
+    }
+
+    @Test
+    public void testHandlesExclamationMark() {
+        String raw = "/** This has an exclamation! */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals("/** This has an exclamation! */", comment.toJava());
+    }
+
+    @Test
+    public void testHandlesQuestionMark() {
+        String raw = "/** Is this a question? */";
+        DocComment comment = DocComment.parse(DocComment.Kind.METHOD, raw);
+        
+        assertTrue("Should return a SingleLineComment instance", comment instanceof SingleLineComment);
+        assertEquals("/** Is this a question? */", comment.toJava());
+    }
+}


### PR DESCRIPTION
A mix of human and LLM code. Claude went down several rabbit holes I had to manually kick it out of, either by explaining things to it or editing the code. 

Something I've noticed in this and other PRs is that Claude is pretty good at single classes and methods, but it tends to peephole too tightly. It doesn't consider solutions that involve the architecture of multiple classes. For instance, here it initially added a parse method to SingleLineComment rather than changing the parse factory method in the superclass to decide which kind of type to create. 