### PR TITLE
Verify doc comments in string literals aren't processed

### DIFF
--- a/core/src/test/java/com/elharo/docfix/DocFixTest.java
+++ b/core/src/test/java/com/elharo/docfix/DocFixTest.java
@@ -76,6 +76,12 @@ public class DocFixTest {
     }
 
     @Test
+    public void testDocCommentInString() {
+        String fixed = DocFix.fix(code);
+        assertTrue(fixed, fixed.contains("\"/** a string literal containing a javadoc comment */\""));
+    }
+
+    @Test
     public void testPreserveLineEndings() {
         code = code.replace('\n', '\r');
         String fixed = DocFix.fix(code);

--- a/core/src/test/resources/com/elharo/math/ComplexNumber.java
+++ b/core/src/test/resources/com/elharo/math/ComplexNumber.java
@@ -100,6 +100,7 @@ public class ComplexNumber implements Cloneable {
         if (denominator == 0) { // Check for single line comment preservation
             throw new ArithmeticException("Division by zero");
         }
+        String s = "/** a string literal containing a javadoc comment */";
         double realPart = (this.real * other.real + this.imaginary * other.imaginary) / denominator;
         double imaginaryPart = (this.imaginary * other.real - this.real * other.imaginary) / denominator;
         return new ComplexNumber(realPart, imaginaryPart);


### PR DESCRIPTION
fixes #224