### PR TITLE
Remove unnecessary git add command in release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,7 +83,6 @@ Update the version in the parent POM from SNAPSHOT to the release version:
 mvn versions:set -DnewVersion=$VERSION
 
 # Commit the version change
-git add .
 git commit -m "Release version $VERSION"
 ```
 


### PR DESCRIPTION
Removed unnecessary 'git add .' command before committing the version change.